### PR TITLE
encrypt file/dirnames for 7z format

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -108,7 +108,7 @@ function backup_package() {
         if [[ "${ZIP_TYPE}" == "zip" ]]; then
             7z a -tzip -mx=9 -p"${ZIP_PASSWORD}" "${BACKUP_FILE_ZIP}" "${BACKUP_DIR}"/*
         else
-            7z a -t7z -m0=lzma2 -mx=9 -mfb=64 -md=32m -ms=on -p"${ZIP_PASSWORD}" "${BACKUP_FILE_ZIP}" "${BACKUP_DIR}"/*
+            7z a -t7z -m0=lzma2 -mx=9 -mfb=64 -md=32m -ms=on -mhe=on -p"${ZIP_PASSWORD}" "${BACKUP_FILE_ZIP}" "${BACKUP_DIR}"/*
         fi
 
         ls -lah "${BACKUP_DIR}"


### PR DESCRIPTION
enable header encryption for encrypted 7z files. currently the archived 7z files leak information about the contained files and directories. if headers were encrypted (only for 7z files), user would need to provide password before the file is opened and file/dirnames are leaked.

should be turned on as this provides even more security. no need to provide information on what's inside the zip file.