### PR TITLE
Execute supercronic as PID 1 process

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -53,4 +53,4 @@ configure_timezone
 configure_cron
 
 # foreground run crond
-supercronic -passthrough-logs -quiet "${CRON_CONFIG_FILE}"
+exec supercronic -passthrough-logs -quiet "${CRON_CONFIG_FILE}"


### PR DESCRIPTION
Execute supercronic as PID 1 process
So, SIGINT can be passed to supercronic instead of entrypoint script shell. Providing quick container restart/redeploy