### PR TITLE
Add TLS support for MySQL and PostgreSQL backups and restores

### DIFF
--- a/docs/using-the-mysql-or-mariadb-backend.md
+++ b/docs/using-the-mysql-or-mariadb-backend.md
@@ -40,6 +40,18 @@ Default: `vaultwarden`
 
 MySQL(MariaDB) password, **required**.
 
+#### MYSQL_SSL_CA
+
+Path to the CA certificate for TLS connection, if used.
+
+#### MYSQL_SSL_CERT
+
+Path to the client certificate for TLS connection, if used.
+
+#### MYSQL_SSL_KEY
+
+Path to the client key for TLS connection, if used.
+
 <br>
 
 

--- a/docs/using-the-postgresql-backend.md
+++ b/docs/using-the-postgresql-backend.md
@@ -48,6 +48,18 @@ PostgreSQL password, **required**.
 
 The login information will be saved in the `~/.pgpass` file.
 
+#### PG_SSL_CA
+
+Path to the CA certificate for TLS connection, if used.
+
+#### PG_SSL_CERT
+
+Path to the client certificate for TLS connection, if used.
+
+#### PG_SSL_KEY
+
+Path to the client key for TLS connection, if used.
+
 <br>
 
 

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -38,13 +38,24 @@ function backup_db_sqlite() {
 
 function backup_db_postgresql() {
     color blue "backup vaultwarden postgresql database"
-
-    pg_dump -Fc -h "${PG_HOST}" -p "${PG_PORT}" -d "${PG_DBNAME}" -U "${PG_USERNAME}" -f "${BACKUP_FILE_DB_POSTGRESQL}"
+    
+    PG_DUMP_CMD=(pg_dump -Fc -h "${PG_HOST}" -p "${PG_PORT}" -d "${PG_DBNAME}" -U "${PG_USERNAME}" -f "${BACKUP_FILE_DB_POSTGRESQL}")
+    
+    if [[ -n "$PG_SSL_CA" ]]; then
+        PG_DUMP_CMD+=(--sslrootcert="$PG_SSL_CA")
+    fi
+    if [[ -n "$PG_SSL_CERT" ]]; then
+        PG_DUMP_CMD+=(--sslcert="$PG_SSL_CERT")
+    fi
+    if [[ -n "$PG_SSL_KEY" ]]; then
+        PG_DUMP_CMD+=(--sslkey="$PG_SSL_KEY")
+    fi
+    
+    "${PG_DUMP_CMD[@]}"
+    
     if [[ $? != 0 ]]; then
         color red "backup vaultwarden postgresql database failed"
-
         send_notification "failure" "Backup failed at $(date +"%Y-%m-%d %H:%M:%S %Z"). Reason: Backup postgresql database failed."
-
         exit 1
     fi
 }
@@ -52,12 +63,23 @@ function backup_db_postgresql() {
 function backup_db_mysql() {
     color blue "backup vaultwarden mysql database"
 
-    mariadb-dump -h "${MYSQL_HOST}" -P "${MYSQL_PORT}" -u "${MYSQL_USERNAME}" -p"${MYSQL_PASSWORD}" "${MYSQL_DATABASE}" > "${BACKUP_FILE_DB_MYSQL}"
+    MYSQL_DUMP_CMD=(mariadb-dump -h "${MYSQL_HOST}" -P "${MYSQL_PORT}" -u "${MYSQL_USERNAME}" -p"${MYSQL_PASSWORD}" "${MYSQL_DATABASE}")
+    
+    if [[ -n "$MYSQL_SSL_CA" ]]; then
+        MYSQL_DUMP_CMD+=(--ssl-ca="$MYSQL_SSL_CA")
+    fi
+    if [[ -n "$MYSQL_SSL_CERT" ]]; then
+        MYSQL_DUMP_CMD+=(--ssl-cert="$MYSQL_SSL_CERT")
+    fi
+    if [[ -n "$MYSQL_SSL_KEY" ]]; then
+        MYSQL_DUMP_CMD+=(--ssl-key="$MYSQL_SSL_KEY")
+    fi
+    
+    "${MYSQL_DUMP_CMD[@]}" > "${BACKUP_FILE_DB_MYSQL}"
+    
     if [[ $? != 0 ]]; then
         color red "backup vaultwarden mysql database failed"
-
         send_notification "failure" "Backup failed at $(date +"%Y-%m-%d %H:%M:%S %Z"). Reason: Backup mysql database failed."
-
         exit 1
     fi
 }

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -78,7 +78,19 @@ function restore_db_sqlite() {
 function restore_db_postgresql() {
     color blue "restore vaultwarden postgresql database"
 
-    pg_restore -h "${PG_HOST}" -p "${PG_PORT}" -d "${PG_DBNAME}" -U "${PG_USERNAME}" -c "${RESTORE_FILE_DB}"
+    PG_RESTORE_CMD=(pg_restore -h "${PG_HOST}" -p "${PG_PORT}" -d "${PG_DBNAME}" -U "${PG_USERNAME}" -c "${RESTORE_FILE_DB}")
+    
+    if [[ -n "$PG_SSL_CA" ]]; then
+        PG_RESTORE_CMD+=(--sslrootcert="$PG_SSL_CA")
+    fi
+    if [[ -n "$PG_SSL_CERT" ]]; then
+        PG_RESTORE_CMD+=(--sslcert="$PG_SSL_CERT")
+    fi
+    if [[ -n "$PG_SSL_KEY" ]]; then
+        PG_RESTORE_CMD+=(--sslkey="$PG_SSL_KEY")
+    fi
+    
+    "${PG_RESTORE_CMD[@]}"
 
     if [[ $? == 0 ]]; then
         color green "restore vaultwarden postgresql database successful"
@@ -90,7 +102,19 @@ function restore_db_postgresql() {
 function restore_db_mysql() {
     color blue "restore vaultwarden mysql database"
 
-    mariadb -h "${MYSQL_HOST}" -P "${MYSQL_PORT}" -u "${MYSQL_USERNAME}" -p"${MYSQL_PASSWORD}" "${MYSQL_DATABASE}" < "${RESTORE_FILE_DB}"
+    MYSQL_RESTORE_CMD=(mariadb -h "${MYSQL_HOST}" -P "${MYSQL_PORT}" -u "${MYSQL_USERNAME}" -p"${MYSQL_PASSWORD}" "${MYSQL_DATABASE}")
+    
+    if [[ -n "$MYSQL_SSL_CA" ]]; then
+        MYSQL_RESTORE_CMD+=(--ssl-ca="$MYSQL_SSL_CA")
+    fi
+    if [[ -n "$MYSQL_SSL_CERT" ]]; then
+        MYSQL_RESTORE_CMD+=(--ssl-cert="$MYSQL_SSL_CERT")
+    fi
+    if [[ -n "$MYSQL_SSL_KEY" ]]; then
+        MYSQL_RESTORE_CMD+=(--ssl-key="$MYSQL_SSL_KEY")
+    fi
+    
+    "${MYSQL_RESTORE_CMD[@]}" < "${RESTORE_FILE_DB}"
 
     if [[ $? == 0 ]]; then
         color green "restore vaultwarden mysql database successful"


### PR DESCRIPTION
Adds TLS support for MySQL and PostgreSQL database backups and restores by introducing new environment variables for SSL certificates.

### Changes

- **Backup & Restore Scripts (`backup.sh` & `restore.sh`)**
    
    - Added support for TLS by introducing the following environment variables:
        - `MYSQL_SSL_CA`, `MYSQL_SSL_CERT`, `MYSQL_SSL_KEY` for MySQL
        - `PG_SSL_CA`, `PG_SSL_CERT`, `PG_SSL_KEY` for PostgreSQL
    - Updated backup and restore commands to use these parameters if set.
- **Documentation Updates (`docs/using-the-mysql-or-mariadb-backend.md`, `docs/using-the-postgresql-backend.md`)**
    
    - Documented new environment variables for TLS support.
    - Provided usage instructions for secure database connections.

### Benefits

- Enables secure database connections with TLS (with custom certificates).

### Testing

- Verified that backups and restores work correctly with and without TLS certificates.
- Tested various with and without certificates.

Let me know if any further adjustments are needed!