### PR TITLE
feat(notification): add telegram notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ And the following ways of notifying backup results are supported.
 
 - Ping (send on completion, start, success, or failure)
 - Mail (SMTP based, send on success and on failure)
+- Telegram (Bot API based, send on start, success, or failure)
 
 <br>
 
@@ -491,6 +492,47 @@ docker run --rm -it -e MAIL_SMTP_VARIABLES='<your smtp variables>' ttionya/vault
 # Or
 
 docker run --rm -it -e MAIL_SMTP_VARIABLES='<your smtp variables>' -e MAIL_TO='<mail send to>' ttionya/vaultwarden-backup:latest mail
+```
+
+<br>
+
+
+
+### Telegram
+
+| Environment Variable | Default Value | Description |
+| --- | --- | --- |
+| TG_ENABLE | `FALSE` | Enable sending Telegram notifications. |
+| TG_BOT_TOKEN | | Telegram bot token. |
+| TG_CHAT_ID | | Telegram chat ID to receive notifications. |
+| TG_WHEN_START | `FALSE` | Send a Telegram message when the backup starts. |
+| TG_WHEN_SUCCESS | `TRUE` | Send a Telegram message when the backup completes successfully. |
+| TG_WHEN_FAILURE | `TRUE` | Send a Telegram message when the backup fails. |
+| TG_MESSAGE_THREAD_ID | | Telegram forum topic ID. Optional. |
+| TG_PARSE_MODE | | Telegram parse mode such as `MarkdownV2` or `HTML`. Optional. |
+| TG_SERVER | `https://api.telegram.org` | Telegram Bot API server. Useful for proxies or self-hosted Bot API endpoints. |
+
+When enabled, the tool sends messages through the Telegram Bot API `sendMessage` endpoint. The message body is composed of the notification subject and content.
+
+<br>
+
+
+
+### Telegram Test
+
+You can use the following command to test Telegram sending. We will add the `-v` flag to display detailed information.
+
+```shell
+docker run --rm -it \
+  -e TG_BOT_TOKEN='<your telegram bot token>' \
+  -e TG_CHAT_ID='<your telegram chat id>' \
+  ttionya/vaultwarden-backup:latest tg
+
+# Or
+
+docker run --rm -it \
+  -e TG_BOT_TOKEN='<your telegram bot token>' \
+  ttionya/vaultwarden-backup:latest tg <telegram chat id>
 ```
 
 <br>

--- a/README_zh.md
+++ b/README_zh.md
@@ -30,6 +30,7 @@
 
 - Ping (完成，开始，成功或失败时发送)
 - Mail (基于 SMTP，成功时和失败时都会发送)
+- Telegram (基于 Bot API，开始、成功或失败时发送)
 
 <br>
 
@@ -488,6 +489,47 @@ docker run --rm -it -e MAIL_SMTP_VARIABLES='<your smtp variables>' ttionya/vault
 # Or
 
 docker run --rm -it -e MAIL_SMTP_VARIABLES='<your smtp variables>' -e MAIL_TO='<mail send to>' ttionya/vaultwarden-backup:latest mail
+```
+
+<br>
+
+
+
+### Telegram
+
+| 环境变量 | 默认值 | 描述 |
+| --- | --- | --- |
+| TG_ENABLE | `FALSE` | 启用 Telegram 通知发送 |
+| TG_BOT_TOKEN | | Telegram 机器人 Token |
+| TG_CHAT_ID | | 接收通知的 Telegram Chat ID |
+| TG_WHEN_START | `FALSE` | 备份开始时发送 Telegram 消息 |
+| TG_WHEN_SUCCESS | `TRUE` | 备份成功时发送 Telegram 消息 |
+| TG_WHEN_FAILURE | `TRUE` | 备份失败时发送 Telegram 消息 |
+| TG_MESSAGE_THREAD_ID | | Telegram 论坛主题 ID，可选 |
+| TG_PARSE_MODE | | Telegram 解析模式，如 `MarkdownV2` 或 `HTML`，可选 |
+| TG_SERVER | `https://api.telegram.org` | Telegram Bot API 服务地址，可用于代理或自建 Bot API |
+
+启用后，工具会通过 Telegram Bot API 的 `sendMessage` 接口发送消息，消息正文由通知标题和内容组成。
+
+<br>
+
+
+
+### Telegram 发送测试
+
+你可以使用下面的命令测试 Telegram 发送功能。我们会增加 `-v` 标志以显示详细信息。
+
+```shell
+docker run --rm -it \
+  -e TG_BOT_TOKEN='<your telegram bot token>' \
+  -e TG_CHAT_ID='<your telegram chat id>' \
+  ttionya/vaultwarden-backup:latest tg
+
+# Or
+
+docker run --rm -it \
+  -e TG_BOT_TOKEN='<your telegram bot token>' \
+  ttionya/vaultwarden-backup:latest tg <telegram chat id>
 ```
 
 <br>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,15 @@ services:
     #   MAIL_WHEN_SUCCESS: 'TRUE'
     #   MAIL_WHEN_FAILURE: 'TRUE'
     #   MAIL_FORCE_THREAD: 'FALSE'
+    #   TG_ENABLE: 'FALSE'
+    #   TG_BOT_TOKEN: ''
+    #   TG_CHAT_ID: ''
+    #   TG_WHEN_START: 'FALSE'
+    #   TG_WHEN_SUCCESS: 'TRUE'
+    #   TG_WHEN_FAILURE: 'TRUE'
+    #   TG_MESSAGE_THREAD_ID: ''
+    #   TG_PARSE_MODE: ''
+    #   TG_SERVER: 'https://api.telegram.org'
     #   TIMEZONE: 'UTC'
     volumes:
       - vaultwarden-data:/bitwarden/data/

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -40,6 +40,24 @@ if [[ "$1" == "ping" ]]; then
     exit 0
 fi
 
+# telegram test
+if [[ "$1" == "tg" ]]; then
+    export_env_file
+    init_env_display
+    init_env_tg
+
+    TG_ENABLE="TRUE"
+    TG_DEBUG="TRUE"
+
+    if [[ -n "$2" ]]; then
+        TG_CHAT_ID="$2"
+    fi
+
+    send_tg "${DISPLAY_NAME} Backup Test" "Your Telegram configuration looks correct."
+
+    exit 0
+fi
+
 # restore
 if [[ "$1" == "restore" ]]; then
     . /app/restore.sh

--- a/scripts/includes.sh
+++ b/scripts/includes.sh
@@ -153,6 +153,50 @@ function send_mail() {
 }
 
 ########################################
+# Send Telegram notification by Bot API.
+# Arguments:
+#     telegram subject
+#     telegram content
+# Outputs:
+#     send telegram result
+########################################
+function send_tg() {
+    local TG_VERBOSE_FLAG=""
+    local TG_API_URL="${TG_SERVER}/bot${TG_BOT_TOKEN}/sendMessage"
+    local TG_TEXT="$1"$'\n'"$2"
+    local TG_DEBUG_COMMAND=""
+    local -a CURL_COMMAND=(curl -m 15 --retry 10 --retry-delay 1 -o /dev/null -s -X POST)
+
+    if [[ "${TG_DEBUG}" == "TRUE" ]]; then
+        TG_VERBOSE_FLAG="-v"
+    fi
+
+    if [[ -n "${TG_VERBOSE_FLAG}" ]]; then
+        CURL_COMMAND+=("${TG_VERBOSE_FLAG}")
+    fi
+    CURL_COMMAND+=(--data-urlencode "chat_id=${TG_CHAT_ID}")
+    CURL_COMMAND+=(--data-urlencode "text=${TG_TEXT}")
+    if [[ -n "${TG_MESSAGE_THREAD_ID}" ]]; then
+        CURL_COMMAND+=(--data-urlencode "message_thread_id=${TG_MESSAGE_THREAD_ID}")
+    fi
+    if [[ -n "${TG_PARSE_MODE}" ]]; then
+        CURL_COMMAND+=(--data-urlencode "parse_mode=${TG_PARSE_MODE}")
+    fi
+
+    if [[ "${TG_DEBUG}" == "TRUE" ]]; then
+        printf -v TG_DEBUG_COMMAND '%q ' "${CURL_COMMAND[@]}" "${TG_API_URL}"
+        color yellow "curl command: ${TG_DEBUG_COMMAND}"
+    fi
+
+    "${CURL_COMMAND[@]}" "${TG_API_URL}"
+    if [[ $? != 0 ]]; then
+        color red "telegram notification sending has failed"
+    else
+        color blue "telegram notification has been sent successfully"
+    fi
+}
+
+########################################
 # Send health check or notification ping.
 # Arguments:
 #     ping status (completion / start / success / failure)
@@ -209,6 +253,10 @@ function send_notification() {
 
     case "$1" in
         start)
+            # telegram
+            if [[ "${TG_ENABLE}" == "TRUE" && "${TG_WHEN_START}" == "TRUE" ]]; then
+                send_tg "${SUBJECT_START}" "$2"
+            fi
             # ping
             send_ping "start" "${SUBJECT_START}" "$2"
             ;;
@@ -216,6 +264,10 @@ function send_notification() {
             # mail
             if [[ "${MAIL_SMTP_ENABLE}" == "TRUE" && "${MAIL_WHEN_SUCCESS}" == "TRUE" ]]; then
                 send_mail "${SUBJECT_SUCCESS}" "$2"
+            fi
+            # telegram
+            if [[ "${TG_ENABLE}" == "TRUE" && "${TG_WHEN_SUCCESS}" == "TRUE" ]]; then
+                send_tg "${SUBJECT_SUCCESS}" "$2"
             fi
             # ping
             send_ping "success" "${SUBJECT_SUCCESS}" "$2"
@@ -225,6 +277,10 @@ function send_notification() {
             # mail
             if [[ "${MAIL_SMTP_ENABLE}" == "TRUE" && "${MAIL_WHEN_FAILURE}" == "TRUE" ]]; then
                 send_mail "${SUBJECT_FAILURE}" "$2"
+            fi
+            # telegram
+            if [[ "${TG_ENABLE}" == "TRUE" && "${TG_WHEN_FAILURE}" == "TRUE" ]]; then
+                send_tg "${SUBJECT_FAILURE}" "$2"
             fi
             # ping
             send_ping "failure" "${SUBJECT_FAILURE}" "$2"
@@ -344,6 +400,7 @@ function init_env() {
     init_env_display
     init_env_ping
     init_env_mail
+    init_env_tg
 
     # CRON
     get_env CRON
@@ -459,6 +516,20 @@ function init_env() {
                 color yellow "MAIL_MESSAGE_ID: auto generate"
             fi
         fi
+    fi
+    color yellow "TG_ENABLE: ${TG_ENABLE}"
+    if [[ "${TG_ENABLE}" == "TRUE" ]]; then
+        color yellow "TG_CHAT_ID: ${TG_CHAT_ID}"
+        color yellow "TG_WHEN_START: ${TG_WHEN_START}"
+        color yellow "TG_WHEN_SUCCESS: ${TG_WHEN_SUCCESS}"
+        color yellow "TG_WHEN_FAILURE: ${TG_WHEN_FAILURE}"
+        if [[ -n "${TG_MESSAGE_THREAD_ID}" ]]; then
+            color yellow "TG_MESSAGE_THREAD_ID: ${TG_MESSAGE_THREAD_ID}"
+        fi
+        if [[ -n "${TG_PARSE_MODE}" ]]; then
+            color yellow "TG_PARSE_MODE: ${TG_PARSE_MODE}"
+        fi
+        color yellow "TG_SERVER: ${TG_SERVER}"
     fi
     color yellow "TIMEZONE: ${TIMEZONE}"
     color yellow "DISPLAY_NAME: ${DISPLAY_NAME}"
@@ -652,4 +723,55 @@ function init_env_mail() {
     else
         MAIL_PARENT_MESSAGE_ID=""
     fi
+}
+
+function init_env_tg() {
+    # TG_ENABLE
+    # TG_BOT_TOKEN
+    # TG_CHAT_ID
+    get_env TG_ENABLE
+    get_env TG_BOT_TOKEN
+    get_env TG_CHAT_ID
+    if [[ "${TG_ENABLE^^}" == "TRUE" && -n "${TG_BOT_TOKEN}" && -n "${TG_CHAT_ID}" ]]; then
+        TG_ENABLE="TRUE"
+    else
+        TG_ENABLE="FALSE"
+    fi
+
+    # TG_SERVER
+    get_env TG_SERVER
+    TG_SERVER="${TG_SERVER:-"https://api.telegram.org"}"
+    TG_SERVER="${TG_SERVER%/}"
+
+    # TG_WHEN_START
+    get_env TG_WHEN_START
+    if [[ "${TG_WHEN_START^^}" == "TRUE" ]]; then
+        TG_WHEN_START="TRUE"
+    else
+        TG_WHEN_START="FALSE"
+    fi
+
+    # TG_WHEN_SUCCESS
+    get_env TG_WHEN_SUCCESS
+    if [[ "${TG_WHEN_SUCCESS^^}" == "FALSE" ]]; then
+        TG_WHEN_SUCCESS="FALSE"
+    else
+        TG_WHEN_SUCCESS="TRUE"
+    fi
+
+    # TG_WHEN_FAILURE
+    get_env TG_WHEN_FAILURE
+    if [[ "${TG_WHEN_FAILURE^^}" == "FALSE" ]]; then
+        TG_WHEN_FAILURE="FALSE"
+    else
+        TG_WHEN_FAILURE="TRUE"
+    fi
+
+    # TG_MESSAGE_THREAD_ID
+    get_env TG_MESSAGE_THREAD_ID
+    TG_MESSAGE_THREAD_ID="${TG_MESSAGE_THREAD_ID:-""}"
+
+    # TG_PARSE_MODE
+    get_env TG_PARSE_MODE
+    TG_PARSE_MODE="${TG_PARSE_MODE:-""}"
 }


### PR DESCRIPTION
# Summary

Add Telegram notification support through the Telegram Bot API.

# Changes

## Features

- Add Telegram notification sending for the following backup events:
  - Backup started
  - Backup succeeded
  - Backup failed

- Add a new `tg` entrypoint command for testing the Telegram configuration.

## Environment Variables

Add support for the following Telegram-related environment variables:

| Variable | Description |
|----------|-------------|
| `TG_ENABLE` | Enable or disable Telegram notifications |
| `TG_BOT_TOKEN` | Telegram Bot API token |
| `TG_CHAT_ID` | Target chat ID |
| `TG_WHEN_START` | Send notification when a backup starts |
| `TG_WHEN_SUCCESS` | Send notification when a backup succeeds |
| `TG_WHEN_FAILURE` | Send notification when a backup fails |
| `TG_MESSAGE_THREAD_ID` | Telegram topic (message thread) ID for forum groups |
| `TG_PARSE_MODE` | Message parse mode (e.g. `Markdown`, `HTML`) |
| `TG_SERVER` | Custom Telegram Bot API server endpoint |

## Documentation

- Add Telegram configuration documentation to:
  - `README.md` (English)
  - `README_zh.md` (Chinese)

- Document how to test the Telegram configuration using the `tg` command.

## Examples

- Add Telegram-related environment variable examples to `docker-compose.yml`.

# Testing

- Verified the shell implementation by reviewing the generated `curl` request path.
- Live testing against a real Telegram Bot API token and chat was **not** performed in the current environment.