### PR TITLE
Add verification of SQLite database backup result and disallow missing database files

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -29,6 +29,8 @@ function backup_init() {
 function backup_db_sqlite() {
     color blue "backup vaultwarden sqlite database"
 
+    check_file_exist "${DATA_DB}"
+
     sqlite3 "${DATA_DB}" ".backup '${BACKUP_FILE_DB_SQLITE}'"
     if [[ $? != 0 ]]; then
         color red "backup vaultwarden sqlite database failed"

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -29,10 +29,13 @@ function backup_init() {
 function backup_db_sqlite() {
     color blue "backup vaultwarden sqlite database"
 
-    if [[ -f "${DATA_DB}" ]]; then
-        sqlite3 "${DATA_DB}" ".backup '${BACKUP_FILE_DB_SQLITE}'"
-    else
-        color yellow "not found vaultwarden sqlite database, skipping"
+    sqlite3 "${DATA_DB}" ".backup '${BACKUP_FILE_DB_SQLITE}'"
+    if [[ $? != 0 ]]; then
+        color red "backup vaultwarden sqlite database failed"
+
+        send_notification "failure" "Backup failed at $(date +"%Y-%m-%d %H:%M:%S %Z"). Reason: Backup sqlite database failed."
+
+        exit 1
     fi
 }
 

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -97,6 +97,7 @@ function test_result() {
 . tests/units/check-rclone-flags-valid/test.sh
 . tests/units/check-rclone-connection-initializing/test.sh
 . tests/units/check-encrypted-rclone-config/test.sh
+. tests/units/backup-db-sqlite-not-exists/test.sh
 . tests/units/backup-zip-file/test.sh
 . tests/units/backup-7z-file/test.sh
 . tests/units/backup-unpackage/test.sh

--- a/tests/units/backup-db-sqlite-not-exists/test.sh
+++ b/tests/units/backup-db-sqlite-not-exists/test.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+TEST_NAME="backup-db-sqlite-not-exists"
+TEST_OUTPUT_DIR="$(pwd)/${OUTPUT_DIR}/${TEST_NAME}"
+TEST_DATA_DIR="$(pwd)/${TEMP_DIR}/${TEST_NAME}"
+
+PASSWORD="f4268105-b464-4b01-8987-d999bfbc5146"
+
+FAILED_NUM=0
+
+color yellow "Starting test case \"${TEST_NAME}\""
+
+function prepare() {
+    mkdir -p "${TEST_OUTPUT_DIR}" "${TEST_DATA_DIR}"
+}
+
+# function start() {
+# }
+
+function test() {
+    color blue "Testing..."
+
+    FOUND_MESSAGE_COUNT=$(docker run --rm \
+        --mount "type=bind,source=${TEST_OUTPUT_DIR},target=${REMOTE_DIR}" \
+        --mount "type=bind,source=${TEST_DATA_DIR},target=/bitwarden/data" \
+        -e "RCLONE_REMOTE_DIR=${REMOTE_DIR}" \
+        -e "ZIP_PASSWORD=${PASSWORD}" \
+        -e "BACKUP_FILE_SUFFIX=test" \
+        "${DOCKER_IMAGE}" \
+        backup | grep -c "cannot access /bitwarden/data/db.sqlite3: No such file")
+
+    if [[ "${FOUND_MESSAGE_COUNT}" -ne 1 ]]; then
+        ((FAILED_NUM++))
+    fi
+}
+
+function cleanup() {
+    sudo rm -rf "${TEST_OUTPUT_DIR}" "${TEST_DATA_DIR}"
+
+    unset TEST_OUTPUT_DIR
+    unset TEST_DATA_DIR
+    unset PASSWORD
+    unset FOUND_MESSAGE_COUNT
+}
+
+prepare
+# start
+test
+cleanup
+
+test_result "${TEST_NAME}" "${FAILED_NUM}"


### PR DESCRIPTION
#248 raised a long-standing bug where the backup result of the SQLite database was not verified. This error could cause the backup script to continue and report success even if the database file backup actually failed. We now add this verification.

The same issue also questioned the rationale for allowing missing database backups to be skipped and marking the backup as successful. To be honest, this design is so old that I have forgotten the original reason. It was most likely intended to support backups for new projects that had not yet created the database file, and less likely as a conditional branch reserved before supporting other database backends.

Regardless, after this modification, when `DB_TYPE` is `sqlite` (the default), the absence of the SQLite database file will cause the backup to fail.